### PR TITLE
Prepend '0' to file name if file index is < 10 . enables easier sorting

### DIFF
--- a/DecryptPluralSightVideos/Decryptor.cs
+++ b/DecryptPluralSightVideos/Decryptor.cs
@@ -257,10 +257,17 @@ namespace DecryptPluralSightVideos
                     if (File.Exists(currPath))
                     {
                         // Create new path with output folder
-                        string newPath = Path.Combine(outputPath,
-                            clip.ClipIndex + ". " + clip.ClipTitle + ".mp4");
-
-                        
+                        string newPath = "";
+                        if (clip.ClipIndex < 10)
+                        {
+                            newPath = Path.Combine(outputPath,
+                                 "0" + clip.ClipIndex + ". " + clip.ClipTitle + ".mp4");
+                        }
+                        else
+                        {
+                            newPath = Path.Combine(outputPath,
+                                clip.ClipIndex + ". " + clip.ClipTitle + ".mp4");
+                        }
 
                         // If length too long, rename it
                         if (newPath.Length > 240)

--- a/DecryptPluralSightVideosGUI/frmMain.cs
+++ b/DecryptPluralSightVideosGUI/frmMain.cs
@@ -385,10 +385,17 @@ namespace DecryptPluralSightVideosGUI
                     if (File.Exists(currPath))
                     {
                         // Create new path with output folder
-                        string newPath = Path.Combine(outputPath,
-                            clip.ClipIndex + ". " + clip.ClipTitle + ".mp4");
-
-
+                        string newPath = "";
+                        if (clip.ClipIndex < 10)
+                        {
+                            newPath = Path.Combine(outputPath,
+                                 "0" + clip.ClipIndex + ". " + clip.ClipTitle + ".mp4");
+                        }
+                        else
+                        {
+                            newPath = Path.Combine(outputPath,
+                                clip.ClipIndex + ". " + clip.ClipTitle + ".mp4");
+                        }
 
                         // If length too long, rename it
                         if (newPath.Length > 240)


### PR DESCRIPTION
Prepend '0' to file name if file index is < 10 . enables easier sorting when a module is added as a playlist in video players.